### PR TITLE
`hashCode`, `getter`, `setter` coverage is omitted if the pojo is not serializable

### DIFF
--- a/src/main/java/org/honton/chas/testpojo/PojoClassTester.java
+++ b/src/main/java/org/honton/chas/testpojo/PojoClassTester.java
@@ -1,6 +1,7 @@
 package org.honton.chas.testpojo;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class PojoClassTester {
 
@@ -33,6 +34,16 @@ public class PojoClassTester {
             }
         }
 
+        if (standard.hashCode() != standard.hashCode()) {
+            System.err.println("hashCode is unstable");
+            return false;
+        }
+
+        if (!Objects.equals(standard.toString(), String.valueOf(standard))) {
+            System.err.println("toString is unstable");
+            return false;
+        }
+
         if (!standard.equals(standard)) {
             System.err.println("this !== this");
             return false;
@@ -45,6 +56,7 @@ public class PojoClassTester {
             System.err.println("this == new Object()");
             return false;
         }
+
         return true;
     }
 
@@ -76,9 +88,10 @@ public class PojoClassTester {
         if(variant == null) {
             return null;
         }
-        variant.toString();
 
-        if (!testJacksonSerialization(variant)) {
+        if (!PojoClass.isJacksonSerializable(variant)) {
+            System.err.println("Skipping '" + pojoClass.getPojoClassSimpleName() + "' serialization tests!");
+        } else if (!testJacksonSerialization(variant)) {
             return null;
         }
 
@@ -90,9 +103,8 @@ public class PojoClassTester {
     }
 
     private boolean testJacksonSerialization(Object variant) throws IOException {
-        return !pojoClass.isJacksonSerializable()
-                || (comparePojos(variant, pojoClass.createCopyThroughMap(variant))
-                        && comparePojos(variant, pojoClass.createCopyThroughString(variant)));
+        return comparePojos(variant, PojoClass.createCopyThroughMap(variant))
+                && comparePojos(variant, PojoClass.createCopyThroughString(variant));
     }
 
     private boolean comparePojos(Object pojo, Object copy) {

--- a/src/test/java/org/honton/chas/testpojo/NotSerializableTest.java
+++ b/src/test/java/org/honton/chas/testpojo/NotSerializableTest.java
@@ -1,18 +1,20 @@
 package org.honton.chas.testpojo;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Data;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreType;
-
-import lombok.Data;
-
 public class NotSerializableTest {
-
     @JsonIgnoreType
+    public static class JsonIgnoreTypeClass {
+    }
+
     @Data
-    static public class NotSerializable {
+    public static class NotSerializable {
+        public NotSerializable(Void param) {
+        }
     }
     
     @Before
@@ -22,9 +24,17 @@ public class NotSerializableTest {
     
     @Test
     public void testNotSerializable() throws Exception {
-        PojoClass pc = PojoClass.from(NotSerializable.class);
-        Assert.assertFalse(pc.isJacksonSerializable());
+        Object value = PojoClass.from(NotSerializable.class).createVariant(-1);
+        Assert.assertFalse(PojoClass.isJacksonSerializable(value));
 
         Assert.assertTrue(new PojoClassTester(NotSerializable.class.getName()).test());
+    }
+
+    @Test
+    public void testJsonIgnoreTypeClass() throws Exception {
+        Object value = PojoClass.from(JsonIgnoreTypeClass.class).createVariant(-1);
+        Assert.assertFalse(PojoClass.isJacksonSerializable(value));
+
+        Assert.assertTrue(new PojoClassTester(JsonIgnoreTypeClass.class.getName()).test());
     }
 }

--- a/src/test/java/org/honton/chas/testpojo/PojoSpyTest.java
+++ b/src/test/java/org/honton/chas/testpojo/PojoSpyTest.java
@@ -1,0 +1,80 @@
+package org.honton.chas.testpojo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.EnumSet;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PojoSpyTest {
+    @Before
+    public void initialize() {
+        PojoClassTester.setClassLoader(getClass().getClassLoader());
+    }
+
+    @Test
+    public void testData() throws Exception {
+        assertTrue(new PojoClassTester(PojoSpy.class.getName()).test());
+
+        assertEquals(EnumSet.allOf(Covered.class), PojoSpy.covered);
+    }
+}
+
+enum Covered {
+    CONSTRUCTOR,
+    GETTER,
+    SETTER,
+    EQUALS,
+    HASH_CODE,
+    TO_STRING
+}
+
+@SuppressWarnings("ALL")
+class PojoSpy {
+    static EnumSet<Covered> covered = EnumSet.noneOf(Covered.class);
+    private String value;
+
+    public PojoSpy() {
+        covered.add(Covered.CONSTRUCTOR);
+    }
+
+    public String getValue() {
+        covered.add(Covered.GETTER);
+
+        return value;
+    }
+
+    public void setValue(String value) {
+        covered.add(Covered.SETTER);
+
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        covered.add(Covered.EQUALS);
+
+        if (this == o) return true;
+        else if (o == null || getClass() != o.getClass()) return false;
+        PojoSpy pojoSpy = (PojoSpy) o;
+        return Objects.equals(value, pojoSpy.value);
+    }
+
+    @Override
+    public int hashCode() {
+        covered.add(Covered.HASH_CODE);
+
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        covered.add(Covered.TO_STRING);
+
+        return "PojoSpy{value='" + value + "'}";
+    }
+}
+


### PR DESCRIPTION
Fixes #6